### PR TITLE
feat: refactor chat interface to use custom useConversation hook for …

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,173 +1,78 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { ChatInput } from "@/components/chat/chat-input";
 import { UnifiedMessage } from "./unified-message";
-import { useSession } from "next-auth/react";
-import { useParams, usePathname, useRouter } from "next/navigation";
-import { getLLMResponse } from "@/actions/ai/getLLMResponse";
-import { Message } from "@/types/llm-response";
-import axios from "axios"
-import { mutate } from "swr";
 import { LoadingBubble } from "./loading-bubble";
-import rejectGenerateVideo from "@/actions/server/handleRejection";
-import { toast } from "sonner";
-import { approveAndGenerateVideo } from "@/actions/server/handleApproval";
+import { useConversation } from "@/hooks/use-conversation"; 
 
 export function ChatInterface() {
   const params = useParams();
-  const convoIdFromUrl = params.conversationId as string;
-  const pathName = usePathname();
-  const session = useSession();
-  const router = useRouter();
-  const user = session.data?.user;
+  const convoIdFromUrl = (params.conversationId as string) || null;
+  const { data: session } = useSession();
 
-  const [messages, setMessages] = useState<Message[]>([]);
+  const {
+    messages,
+    isLoading,
+    isSendingMessage,
+    loadingMessageId,
+    handleSendMessage,
+    handleApproveCode,
+    handleRejectCode,
+  } = useConversation(convoIdFromUrl);
+
   const [inputValue, setInputValue] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [isLoadingId, setIsLoadingId] = useState<string | null>(null);
-  const [conversationId, setConversationId] = useState(convoIdFromUrl || "");
-
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  // Scrolls the chat to the latest message and focuses the input whenever messages change.
+
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (messages.length || isSendingMessage) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
     inputRef.current?.focus();
-  }, [messages]);
+  }, [messages, isSendingMessage]);
 
-  // Updates the internal conversation ID state if the URL parameter changes.
-  useEffect(() => {
-    if (convoIdFromUrl && convoIdFromUrl !== conversationId) {
-      setConversationId(convoIdFromUrl);
-    }
-  }, [convoIdFromUrl, conversationId]);
-
-  // Loads the chat history from the server when the user or conversation ID changes.
-  useEffect(() => {
-    if (user && conversationId) {
-      axios.get(`/api/chat/${conversationId}`)
-        .then(res => setMessages(res.data))
-        .catch(err => {
-          console.error(err);
-          toast.error(`Unable to load conversation ${conversationId}`);
-          router.push('/chat');
-        });
-    }
-  }, [conversationId, user]);
-
-  if (!user) return;
-
-  const handleSendMessage = async (userPrompt: string) => {
-    if (!userPrompt.trim()) return;
-
-    const userMessage: Message = {
-      id: crypto.randomUUID(),
-      role: "user",
-      content: userPrompt,
-      timestamp: new Date(),
-    }
-
-    setMessages(prev => [...prev, userMessage]);
+  const handleSubmit = useCallback((prompt: string) => {
+    handleSendMessage(prompt);
     setInputValue("");
-    setIsLoading(true);
+  }, [handleSendMessage]);
 
-    const { assistantResponse, conversationId: newConversationId, newTitleGenerated } = await getLLMResponse({ conversationId, userId: user.id, userPrompt });
-    if (newTitleGenerated) {
-      mutate("/api/conversations");
-    }
-    setMessages(prev => [...prev, assistantResponse]);
-    if (conversationId === "") {
-      setConversationId(newConversationId);
-      if (pathName !== `/chat/${newConversationId}`) {
-        router.push(`/chat/${newConversationId}`);
-      }
-    }
-    setIsLoading(false);
+  if (!session?.user) return null; 
+  
+  if (isLoading && convoIdFromUrl) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <LoadingBubble />
+      </div>
+    );
   }
-
-  const handleApproveCode = async (messageId: string, codeContent: string) => {
-    setIsLoadingId(messageId);
-
-    try {
-      const quality = "-qm";     // <-- Now hardcoding might make a settings in future
-      const res = await approveAndGenerateVideo(messageId, codeContent, quality);
-
-      if (res.status === 'success' && res.videoId) {
-        toast.success(res.message);
-        setMessages(prev =>
-          prev.map(msg =>
-            msg.id === messageId
-              ? { ...msg, isApproved: true, isRejected: false, videoId: res.videoId }
-              : msg
-          )
-        );
-      } else {
-        throw new Error(res.message || "Failed to generate video.");
-      }
-    } catch (error: unknown) {
-      console.error("Approval / video generation failed:", error);
-      const errorMessage = error instanceof Error ? error.message : "Failed to generate video. Please try again.";
-      toast.error(errorMessage);
-    } finally {
-      setIsLoadingId(null);
-    }
-  };
-
-  const handleRejectCode = async (id: string) => {
-    setIsLoadingId(id);
-    try {
-      const result = await rejectGenerateVideo(id);
-      if (result.success) {
-        setMessages((msgs) =>
-          msgs.map((m) =>
-            m.id === id ? { ...m, isRejected: true } : m
-          )
-        );
-      } else {
-        toast.error(result.message);
-      }
-      const rejectionMessage: Message = {
-        id: Date.now().toString(),
-        role: "system",
-        content: "You've rejected the code. Please provide more details about what changes you'd like to make.",
-        timestamp: new Date(),
-
-      };
-      setMessages(prev => [...prev, rejectionMessage]);
-
-    } catch (err: unknown) {
-      console.error("Rejection failed:", err);
-      toast.error("Rejection failed, please try again later.");
-    } finally {
-      setIsLoadingId(null);
-    }
-  };
 
   return (
     <div className="container mx-auto h-[calc(100vh-3.5rem)] w-full flex flex-col justify-between gap-1 pb-1">
       <div className="flex flex-1 flex-col rounded-md bg-card">
-        <div className="flex-1 p-4 space-y-4">
+        <div className="flex-1 p-4 space-y-4 overflow-y-auto">
           {messages.map((message) => (
             <UnifiedMessage
               key={message.id}
               message={message}
               onApprove={handleApproveCode}
               onReject={handleRejectCode}
-              isLoading={isLoadingId === message.id}
+              isLoading={loadingMessageId === message.id}
             />
           ))}
-          {isLoading && <LoadingBubble />}
+          {isSendingMessage && <LoadingBubble />}
           <div ref={messagesEndRef} />
         </div>
-        <div className="sticky bottom-0 flex flex-col gap-2 pb-1 bg-background">
+        <div className="sticky bottom-0 flex flex-col gap-2 p-2 bg-background">
           <div className="p-2 bg-accent rounded-[25px]">
             <ChatInput
               ref={inputRef}
               value={inputValue}
-              onChange={setInputValue}
-              onSubmit={handleSendMessage}
-              isLoading={isLoading}
+              onChange={setInputValue} 
+              onSubmit={handleSubmit} 
+              isLoading={isSendingMessage}
               placeholder="Describe the scientific concept you want to visualize..."
             />
           </div>

--- a/src/hooks/use-conversation.ts
+++ b/src/hooks/use-conversation.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import useSWR, { mutate } from 'swr';
+import { useRouter, usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { toast } from "sonner";
+import { Message } from "@/types/llm-response";
+import { getLLMResponse } from "@/actions/ai/getLLMResponse";
+import { approveAndGenerateVideo } from "@/actions/server/handleApproval";
+import rejectGenerateVideo from "@/actions/server/handleRejection";
+import axios from "axios";
+
+const fetcher = (url: string) => axios.get(url).then(res => res.data);
+
+export function useConversation(conversationId: string | null) {
+  const router = useRouter();
+  const pathName = usePathname();
+  const { data: session } = useSession();
+  const user = session?.user;
+
+  const { data: messages = [], mutate: mutateMessages, error } = useSWR<Message[]>(
+    user && conversationId ? `/api/chat/${conversationId}` : null,
+    fetcher,
+    {
+      onError: (err) => {
+        console.error(err);
+        toast.error(`Unable to load conversation ${conversationId}`);
+        router.push('/chat');
+      }
+    }
+  );
+
+  const [isSendingMessage, setIsSendingMessage] = useState(false);
+  const [loadingMessageId, setLoadingMessageId] = useState<string | null>(null);
+
+  const handleSendMessage = useCallback(async (userPrompt: string) => {
+    if (!userPrompt.trim() || !user) return;
+
+    const userMessage: Message = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: userPrompt,
+      timestamp: new Date(),
+    };
+
+    await mutateMessages(prev => [...(prev || []), userMessage], false);
+    setIsSendingMessage(true);
+
+    const { assistantResponse, conversationId: newConversationId, newTitleGenerated } = await getLLMResponse({
+      conversationId: conversationId || "",
+      userId: user.id,
+      userPrompt,
+    });
+
+    if (newTitleGenerated) {
+      mutate("/api/conversations");
+    }
+
+    await mutateMessages(prev => [...(prev || []), assistantResponse], false);
+
+    if (!conversationId && newConversationId) {
+      if (pathName !== `/chat/${newConversationId}`) {
+        router.push(`/chat/${newConversationId}`);
+      }
+    }
+
+    setIsSendingMessage(false);
+  }, [user, conversationId, mutateMessages, router, pathName]);
+
+  const handleApproveCode = useCallback(async (messageId: string, codeContent: string) => {
+    setLoadingMessageId(messageId);
+    try {
+      const quality = "-qm";
+      const res = await approveAndGenerateVideo(messageId, codeContent, quality);
+
+      if (res.status === 'success' && res.videoId) {
+        toast.success(res.message);
+        mutateMessages(currentMessages =>
+          currentMessages?.map(msg =>
+            msg.id === messageId
+              ? { ...msg, isApproved: true, isRejected: false, videoId: res.videoId }
+              : msg
+          ), false);
+      } else {
+        throw new Error(res.message || "Failed to generate video.");
+      }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : "Failed to generate video. Please try again.";
+      toast.error(errorMessage);
+    } finally {
+      setLoadingMessageId(null);
+    }
+  }, [mutateMessages]);
+
+  const handleRejectCode = useCallback(async (messageId: string) => {
+    setLoadingMessageId(messageId);
+    try {
+      const result = await rejectGenerateVideo(messageId);
+      if (result.success) {
+        toast.info("Code rejected. Please describe the changes you need in your next message.");
+        mutateMessages(currentMessages =>
+          currentMessages?.map(m =>
+            m.id === messageId ? { ...m, isRejected: true, isApproved: false } : m
+          ), false);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (err: unknown) {
+      console.error("Rejection failed:", err);
+      toast.error("Rejection failed, please try again later.");
+    } finally {
+      setLoadingMessageId(null);
+    }
+  }, [mutateMessages]);
+
+  return {
+    messages,
+    isLoading: !messages && !error,
+    isSendingMessage,
+    loadingMessageId,
+    handleSendMessage,
+    handleApproveCode,
+    handleRejectCode,
+  };
+}


### PR DESCRIPTION
The ChatInterface component was managing a significant amount of state, data fetching, and business logic, making it complex and difficult to maintain.

This refactoring introduces a new `useConversation` custom hook to serve as a single source of truth for chat state and actions. This decouples the business logic from the presentation layer.

Key improvements include:
- Replaced manual `axios` fetching in `useEffect` with `useSWR` for robust data fetching, caching, and revalidation.
- Encapsulated all API interactions (`sendMessage`, `approveCode`, `rejectCode`) within the new hook.
- Simplified the `ChatInterface` component, making it primarily responsible for rendering the UI.
- Correctly implemented SWR's global `mutate` to refresh the conversation list when a new title is generated.
- Memoized handler functions with `useCallback` to prevent unnecessary re-renders of child components.